### PR TITLE
Fix mistakes + reuse in cpc-dev-tool-chain

### DIFF
--- a/z80.html
+++ b/z80.html
@@ -1619,7 +1619,7 @@
 <tr><td>	<b>sbc</b> a,iyh		</td><td>	2	</td><td>	fd 9c		</td></tr>
 <tr><td>	<b>sbc</b> a,l		</td><td>	1	</td><td>	9d		</td></tr>
 <tr><td>	<b>sbc</b> a,ixl	</td><td>	2	</td><td>	dd 9d		</td></tr>
-<tr><td>	<b>sbc</b> a,iyl	</td><td>	2	</td><td>	fc 9d		</td></tr>
+<tr><td>	<b>sbc</b> a,iyl	</td><td>	2	</td><td>	fd 9d		</td></tr>
 <tr><td>	<b>sbc</b> a,nn		</td><td>	2	</td><td>	de nn		</td></tr>
 <tr><td>	<b>sbc</b> hl,bc	</td><td>	4	</td><td>	ed 42		</td></tr>
 <tr><td>	<b>sbc</b> hl,de	</td><td>	4	</td><td>	ed 52		</td></tr>
@@ -1815,8 +1815,8 @@
 </thead>
 <tbody>
 <tr><td>	<b>srl</b> (hl)		</td><td>	4	</td><td>	cb 3e	</td></tr>
-<tr><td>	<b>srl</b> (ix+nn)	</td><td>	7	</td><td>	cb 3e	</td></tr>
-<tr><td>	<b>srl</b> (iy+nn)	</td><td>	7	</td><td>	cb 3e	</td></tr>
+<tr><td>	<b>srl</b> (ix+nn)	</td><td>	7	</td><td>	dd cb 3e	</td></tr>
+<tr><td>	<b>srl</b> (iy+nn)	</td><td>	7	</td><td>	fd cb 3e	</td></tr>
 <tr><td>	<b>srl</b> a		</td><td>	2	</td><td>	cb 3f	</td></tr>
 <tr><td>	<b>srl</b> b		</td><td>	2	</td><td>	cb 38	</td></tr>
 <tr><td>	<b>srl</b> c		</td><td>	2	</td><td>	cb 39	</td></tr>
@@ -1842,10 +1842,10 @@
 <tr><td>	<b>sub</b> d		</td><td>	1	</td><td>	92		</td></tr>
 <tr><td>	<b>sub</b> e		</td><td>	1	</td><td>	93		</td></tr>
 <tr><td>	<b>sub</b> h		</td><td>	1	</td><td>	94		</td></tr>
-<tr><td>	<b>sub</b> ixh		</td><td>	2	</td><td>	ff 94		</td></tr>
+<tr><td>	<b>sub</b> ixh		</td><td>	2	</td><td>	dd 94		</td></tr>
 <tr><td>	<b>sub</b> iyh		</td><td>	2	</td><td>	fd 94		</td></tr>
 <tr><td>	<b>sub</b> l		</td><td>	1	</td><td>	95		</td></tr>
-<tr><td>	<b>sub</b> ixl		</td><td>	2	</td><td>	ff 95		</td></tr>
+<tr><td>	<b>sub</b> ixl		</td><td>	2	</td><td>	dd 95		</td></tr>
 <tr><td>	<b>sub</b> iyl		</td><td>	2	</td><td>	fd 95		</td></tr>
 <tr><td>	<b>sub</b> nn		</td><td>	2	</td><td>	d6 nn		</td></tr>
 </tbody>


### PR DESCRIPTION
Hi!

In 2013, based on Kevin Thacker (arnoldemu) and Richard (Executioner) published data about Z80 instructions and timings, I wrote a visually laid out summary document and published it on http://www.cpcwiki.eu/forum/programming/craving-for-speed-a-visual-cheat-sheet-to-help-optimizing-your-code-to-death/

I found this week your document https://borilla.co.uk/z80.html .

Thanks for sharing!

I found minor issues, this PR fixes them.

How did I find those issues?

I wrote scripts to:
* parse your document
* generate macros for undocumented instructions for sdasz80 (work in progress, not yet shared)
* generate tables so that sdasz80 knows about CPC timings and reports them on output assembly listings

And the script produced inconsistencies, which I tracked down to these changes.

Result will be shared on https://github.com/cpcitor/cpc-dev-tool-chain and you will get credit.

Are you okay with parsing your document like this for the purpose of enhancing cpc-dev-tool-chain?




References justifying changes:
* fc and ff are not Z80 prefix, cb 3e cannot be same for 3 different instructions
* SBC and SUB http://www.z80.info/z80undoc.htm
* SRL: http://www.cantrell.org.uk/david/tech/cpc/cpc-firmware/z80.pl?s#SRL http://quasar.cpcscene.net/doku.php?id=iassem:z80init
