### PR TITLE
Add missing instructions `cp i[xy][hl]`.

### DIFF
--- a/z80.html
+++ b/z80.html
@@ -607,6 +607,10 @@
 <tr><td>	<b>cp</b> e		</td><td>	1	</td><td>	bb		</td></tr>
 <tr><td>	<b>cp</b> h		</td><td>	1	</td><td>	bc		</td></tr>
 <tr><td>	<b>cp</b> l		</td><td>	1	</td><td>	bd		</td></tr>
+<tr><td>	<b>cp</b> ixh		</td><td>	1	</td><td>	dd bc		</td></tr>
+<tr><td>	<b>cp</b> ixl		</td><td>	1	</td><td>	dd bd		</td></tr>
+<tr><td>	<b>cp</b> iyh		</td><td>	1	</td><td>	fd bc		</td></tr>
+<tr><td>	<b>cp</b> iyl		</td><td>	1	</td><td>	fd bd		</td></tr>
 <tr><td>	<b>cp</b> nn		</td><td>	2	</td><td>	fe nn		</td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Just noticed because I wanted to use them and noticed no macro was generated from your list.

Found opcodes on http://www.z80.info/z80undoc.htm

There might be more.
